### PR TITLE
Fix utc timezone helper

### DIFF
--- a/shared/cron.py
+++ b/shared/cron.py
@@ -1,5 +1,5 @@
 from croniter import croniter, CroniterBadCronError
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Optional
 
 
@@ -33,4 +33,4 @@ def utcnow() -> datetime:
     Returns:
         datetime: The current UTC datetime.
     """
-    return datetime.now(datetime.timetz.utc)
+    return datetime.now(timezone.utc)


### PR DESCRIPTION
## Summary
- fix utcnow helper in cron utilities

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_683f3d03ae8883259b1f4da122136a4e